### PR TITLE
Fix workflow branch configuration: change base to main

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -4,11 +4,11 @@ name: CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "base" branch
+  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "base" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "base" ]
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This pull request updates the CI workflow configuration to trigger only on the `main` branch instead of the `base` branch.

Workflow configuration update:

* [`.github/workflows/blank.yml`](diffhunk://#diff-92f8d88918506bf156b28773f44c413b5bdc170468e8df422cf64bd9fcf8198dL7-R11): Changed workflow triggers for both push and pull request events to use the `main` branch instead of `base`.